### PR TITLE
feat: Add auto-shutdown based on player count

### DIFF
--- a/autoshutdown.go
+++ b/autoshutdown.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/Tnze/go-mc/bot"
+	"github.com/jaredallard/minecraft-preempt/pkg/config"
+	"github.com/jaredallard/minecraft-preempt/pkg/instance"
+
+	"github.com/golang/glog"
+)
+
+type serverStatus struct {
+	Players struct {
+		Online int
+	}
+}
+
+func pingStatus(addr string, port int) (*serverStatus, error) {
+	resp, _, err := bot.PingAndListTimeout(addr, port, time.Second*5)
+	if err != nil {
+		return nil, err
+	}
+
+	var s serverStatus
+	err = json.Unmarshal(resp, &s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &s, nil
+}
+
+func maybeShutdown(conf *config.ProxyConfig, google *instance.Client) error {
+	if time.Now().Sub(playersLastSeenAt) < conf.Server.ShutDownAfter {
+		return nil
+	}
+
+	glog.Info("shutting down instance because there have been no players in a while")
+	return google.Stop(conf.Instance.Project, conf.Instance.Zone, conf.Instance.ID)
+}

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,4 +1,5 @@
 version: 1
+
 server:
   hostname: yourhost.com/ip
   port: 25565
@@ -6,6 +7,13 @@ server:
   # Get from here: https://wiki.vg/Protocol_History
   protocolVersion: 490 
   textVersion: 1.14.3
+
+  # Shut down the server after this amount of time has passed since the last user left.
+  # This must be at least 1 minute, because that is how often the server is pinged.
+  # Set to zero if you do not want this behavior.
+  # See https://golang.org/pkg/time/#ParseDuration for syntax.
+  shutDownAfter: 5m
+
 instance:
   # GCP ONLY RIGHT NOW
   # ID of your instance

--- a/main.go
+++ b/main.go
@@ -111,10 +111,6 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Println(conf.Server.ShutDownAfter)
-
-	return
-
 	google := instance.NewClient()
 
 	// Listen for incoming connections.

--- a/main.go
+++ b/main.go
@@ -150,6 +150,10 @@ func main() {
 				// Shut down instance if there are no players
 				// remaining after the specified time in config
 				err = maybeShutdown(conf, google)
+				if err != nil {
+					glog.Warningf("unable to auto-shutdown server: %v", err)
+					return
+				}
 			}
 
 			time.Sleep(serverPollRate)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"gopkg.in/yaml.v2"
 )
@@ -26,6 +27,9 @@ type ProxyConfig struct {
 
 		// Version of the server
 		Version string `yaml:"textVersion"`
+
+		// ShutDownAfter this amount of time has passed since the last user left
+		ShutDownAfter time.Duration `yaml:"shutDownAfter"`
 	} `yaml:"server"`
 
 	// Instance is a GCP instance

--- a/pkg/instance/client.go
+++ b/pkg/instance/client.go
@@ -11,8 +11,12 @@ import (
 
 var (
 	// ErrNotStopped is an error that is thrown when an instance is attempted
-	// to be stopped but is found to be not running
+	// to be started but is found to be running
 	ErrNotStopped = errors.New("Not stopped")
+
+	// ErrNotRunning is an error that is thrown when an instance is attempted
+	// to be stopped but is found to be not running
+	ErrNotRunning = errors.New("Not running")
 )
 
 // Client is a gcs client
@@ -64,7 +68,7 @@ func (c *Client) Status(project, zone, instanceID string) (string, error) {
 	return i.Status, nil
 }
 
-// Start a instance if it's not already running
+// Start an instance if it's not already running
 func (c *Client) Start(project, zone, instanceID string) error {
 	_, comp, err := c.getClient()
 	if err != nil {
@@ -82,6 +86,28 @@ func (c *Client) Start(project, zone, instanceID string) error {
 	}
 
 	sr := comp.Instances.Start(project, zone, instanceID)
+	_, err = sr.Do()
+	return err
+}
+
+// Stop an instance
+func (c *Client) Stop(project, zone, instanceID string) error {
+	_, comp, err := c.getClient()
+	if err != nil {
+		return err
+	}
+
+	gr := comp.Instances.Get(project, zone, instanceID)
+	i, err := gr.Do()
+	if err != nil {
+		return err
+	}
+
+	if i.Status != "RUNNING" {
+		return ErrNotRunning
+	}
+
+	sr := comp.Instances.Stop(project, zone, instanceID)
 	_, err = sr.Do()
 	return err
 }


### PR DESCRIPTION
I have tested none of this. But the logic goes like this:

Every time the server is pinged...

- If the server is not running, do nothing
- Else, if there is at least 1 player is online, `playersLastSeenAt` is set to the current time
- If the duration between `playersLastSeenAt` and now (i.e., how long it has been since we last saw a player) is less than what is configured, do nothing
- Else, shut down the instance

Test it and let me know if it works lol