### PR TITLE
feat(connection): track connections only on login

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golang 1.20.1
+golang 1.20.2
 goreleaser 1.15.2
 golangci-lint 1.51.1

--- a/cmd/minecraft-preempt/connection.go
+++ b/cmd/minecraft-preempt/connection.go
@@ -40,6 +40,8 @@ type Connection struct {
 	// s is the server we're proxying to
 	s *Server
 
+	// hooks contains hooks that are called when certain events happen
+	// on the connection.
 	hooks *ConnectionHooks
 }
 


### PR DESCRIPTION
**What this PR does**: This PR changes the connection tracking logic to only consider connections that made it to the login state, anything else (e.g., status) will not be tracked.
