### PR TITLE
feat!: use a single listener

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,24 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.21.1"
+          cache: false # golangci-lint does it's own caching of this.
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.54.2

--- a/README.md
+++ b/README.md
@@ -13,15 +13,16 @@ First, define a configuration file for your server. The format is like so:
 
 ### Top level
 
-| Key       | Description          |
-| --------- | -------------------- |
-| `servers` | Array of all servers |
+| Key             | Description               |
+| --------------- | ------------------------- |
+| `listenAddress` | The address to listen on. |
+| `servers`       | Array of all servers      |
 
 #### Server
 
 | Key             | Description                      |
 | --------------- | -------------------------------- |
-| `name`          | The name of the server.          |
+| `hostname`      | The hostname of the server.      |
 | `listenAddress` | The address to listen on.        |
 | `gcp`           | The GCP configuration            |
 | `docker`        | The Docker configuration         |
@@ -43,7 +44,9 @@ First, define a configuration file for your server. The format is like so:
 | ------------- | -------------------- |
 | `containerID` | Container ID or name |
 
-Specifying a configuration can be done with `--config`, for a file path. Or, for serverless environments, the config can be passed as a base64 encoding yaml string through the environment variable `CONFIG_BASE64`.
+Specifying a configuration can be done with `--config`, for a file path.
+Or, for serverless environments, the config can be specified with the
+`CONFIG` environment variable.
 
 ## License
 

--- a/cmd/minecraft-preempt/connection.go
+++ b/cmd/minecraft-preempt/connection.go
@@ -172,8 +172,7 @@ func (c *Connection) checkState(ctx context.Context, state minecraft.ClientState
 
 	switch state {
 	case minecraft.ClientStateCheck: // Status request
-		c.status(ctx, status)
-		return nil, nil
+		return nil, c.status(ctx, status)
 	case minecraft.ClientStatePlayerLogin: // Login request
 		// read the next packet to get the login information
 		login, originalLogin, err := c.ReadLoginStart()

--- a/cmd/minecraft-preempt/proxy.go
+++ b/cmd/minecraft-preempt/proxy.go
@@ -230,15 +230,14 @@ func (p *Proxy) Stop(ctx context.Context) error {
 			for {
 				// check if we have no connections
 				if server.connections.Load() == 0 {
-					break
+					break // stop watching this server, but check others if present.
 				}
 
-				// sleep for 100ms
-				time.Sleep(100 * time.Millisecond)
-
-				// handle context cancellation
-				if err := ctx.Err(); err != nil {
-					return err
+				// wait before checking again, but also break if the context is cancelled
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(100 * time.Millisecond):
 				}
 			}
 		}

--- a/cmd/minecraft-preempt/proxy.go
+++ b/cmd/minecraft-preempt/proxy.go
@@ -17,6 +17,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net"
 	"sync/atomic"
 	"time"
@@ -38,24 +40,24 @@ type Proxy struct {
 	// listenAddress is the address to listen on (the proxy)
 	listenAddress string
 
-	// server is the underlying server that this
-	// proxy is proxying to
-	server *Server
+	// servers is a map of server hostnames to their server information.
+	servers map[string]*Server
 
 	// connections is the number of connections we have
 	connections atomic.Uint64
-
-	// emptySince is the time we've been empty (had no connections)
-	// since
-	emptySince atomic.Pointer[time.Time]
 }
 
 // NewProxy creates a new proxy
-func NewProxy(log *log.Logger, listenAddress string, s *Server) *Proxy {
+func NewProxy(log *log.Logger, listenAddress string, s []*Server) *Proxy {
+	servers := make(map[string]*Server)
+	for _, server := range s {
+		servers[server.config.Hostname] = server
+	}
+
 	return &Proxy{
 		log:           log,
 		listenAddress: listenAddress,
-		server:        s,
+		servers:       servers,
 	}
 }
 
@@ -69,43 +71,47 @@ func (p *Proxy) watcher(ctx context.Context) error {
 			return ctx.Err()
 		}
 
-		// if we have connections, don't try to stop the server
-		if p.connections.Load() != 0 {
-			p.log.Info("Proxy status", "connections", p.connections.Load())
-			continue
-		}
-
-		status, err := p.server.GetStatus(ctx)
-		if err != nil {
-			p.log.Error("failed to get server status", "err", err)
-			continue
-		}
-		if status != cloud.StatusRunning {
-			p.log.Debug("Server is not running, skipping shutdown check")
-			continue
-		}
-
-		// load the emptySince pointer and check if we've never been empty
-		emptySincePtr := p.emptySince.Load()
-		if emptySincePtr == nil {
-			now := time.Now()
-			emptySincePtr = &now
-			p.emptySince.Store(emptySincePtr)
-		}
-
-		emptySince := *emptySincePtr
-		shouldShutdown := time.Since(emptySince) > p.server.config.ShutdownAfter
-		untilShutdown := time.Until(emptySince.Add(p.server.config.ShutdownAfter))
-
-		p.log.Info("Proxy status", "connections", p.connections.Load(), "shutdown_in", untilShutdown)
-		if shouldShutdown {
-			p.log.Info("No connections in configured time, stopping server")
-			if err := p.server.Stop(ctx); err != nil {
-				p.log.Error("failed to stop server", "err", err)
+		// for each server, check the status. Shutdown if we're empty longer
+		// than our configured time.
+		for serverAddress, server := range p.servers {
+			log := p.log.With("server", serverAddress)
+			// if we have connections, don't try to stop the server
+			if p.connections.Load() != 0 {
+				log.Info("Proxy status", "connections", p.connections.Load())
+				continue
 			}
 
-			// reset the emptySince time
-			p.emptySince.Store(nil)
+			status, err := server.GetStatus(ctx)
+			if err != nil {
+				log.Error("failed to get server status", "err", err)
+				continue
+			}
+			if status != cloud.StatusRunning {
+				continue
+			}
+
+			// load the emptySince pointer and check if we've never been empty
+			emptySincePtr := server.emptySince.Load()
+			if emptySincePtr == nil {
+				now := time.Now()
+				emptySincePtr = &now
+				server.emptySince.Store(emptySincePtr)
+			}
+
+			emptySince := *emptySincePtr
+			shouldShutdown := time.Since(emptySince) > server.config.ShutdownAfter
+			untilShutdown := time.Until(emptySince.Add(server.config.ShutdownAfter))
+
+			log.Info("Proxy status", "connections", p.connections.Load(), "shutdown_in", untilShutdown)
+			if shouldShutdown {
+				log.Info("No connections in configured time, stopping server")
+				if err := server.Stop(ctx); err != nil {
+					log.Error("failed to stop server", "err", err)
+				}
+
+				// reset the emptySince time
+				server.emptySince.Store(nil)
+			}
 		}
 	}
 
@@ -120,81 +126,97 @@ func (p *Proxy) Start(ctx context.Context) error {
 	}
 	p.Listener = l
 
-	// attempt to populate the server's status
-	mcStatus, err := minecraft.GetServerStatus(p.server.config.Minecraft.Hostname, p.server.config.Minecraft.Port)
-	if err != nil {
-		p.log.Warn("Failed to get initial server status for protocol detection, will fetch on first connection", "err", err)
-	} else {
-		p.server.lastMinecraftStatus.Store(mcStatus)
-		p.log.Info("Detected server version", "version", mcStatus.Version.Name, "protocol", mcStatus.Version.Protocol)
-	}
-
 	// start the watcher
 	go func() {
-		if err := p.watcher(ctx); err != nil {
-			p.log.Error("failed to start watcher", "err", err)
-			// TODO(jaredallard): handle this better?
+		if err := p.watcher(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			p.log.Error("Failed to start watcher", "err", err)
+			// TODO(jaredallard): Trigger shutdown of proxy when this happens.
 		}
 	}()
 
 	p.log.Info("Proxy started", "address", p.listenAddress)
-
 	for {
-		rawConn, err := l.Accept()
-		if err != nil {
-			// handle context cancel or net closed
-			if errors.Is(err, context.Canceled) || errors.Is(err, net.ErrClosed) {
-				// context cancel should propagate the error
-				if errors.Is(err, context.Canceled) {
-					return err
-				}
+		if err := p.accept(ctx); err != nil {
+			p.log.Error("failed to accept connection", "err", err)
+		}
+	}
+}
 
-				// successful exit if we're closed
-				return nil
+// accept accepts a connection on the proxy listener.
+func (p *Proxy) accept(ctx context.Context) error {
+	rawConn, err := p.Listener.Accept()
+	if err != nil {
+		// handle context cancel or net closed
+		if errors.Is(err, context.Canceled) || errors.Is(err, net.ErrClosed) {
+			// context cancel should propagate the error
+			if errors.Is(err, context.Canceled) {
+				return err
 			}
 
-			// otherwise, log the error and continue
-			log.Error("failed to accept connection", "err", err)
-			continue
+			// successful exit if we're closed
+			return nil
 		}
 
-		// tracks if this connection made it to the login state
-		// HACK(jaredallard): We should do something better than this.
-		var madeItToLogin bool
-
-		// create a new connection
-		conn := NewConnection(&rawConn, p.log, p.server, &ConnectionHooks{
-			OnLogin: func(l *minecraft.LoginStart) {
-				p.log.Info("Login initiated", "username", l.Name)
-				// track that we made it to login state for connection
-				// tracking
-				madeItToLogin = true
-
-				// reset the emptySince time
-				p.emptySince.Store(nil)
-				p.connections.Add(1)
-			},
-			OnClose: func() {
-				// only decrement if we made it to login state, where we
-				// would've incremented the connection count
-				if madeItToLogin {
-					p.connections.Add(^uint64(0))
-				}
-			},
-		})
-		connAddr := rawConn.Socket.RemoteAddr().String()
-
-		// proxy the connection in a goroutine
-		p.log.Debug("Handling connection", "addr", connAddr)
-		go func() {
-			if err := conn.Proxy(ctx); err != nil {
-				p.log.Error("failed to proxy connection", "err", err)
-			}
-			defer conn.Close()
-
-			p.log.Info("Connection closed", "addr", connAddr)
-		}()
+		return fmt.Errorf("failed to accept connection: %w", err)
 	}
+	minecraftConn := &minecraft.Client{Conn: &rawConn}
+
+	log := p.log.With("client", rawConn.Socket.RemoteAddr())
+	h, err := minecraftConn.Handshake()
+	if err != nil {
+		// don't log EOF
+		if !errors.Is(err, io.EOF) {
+			return errors.Wrap(err, "failed to handshake")
+		}
+		return nil
+	}
+
+	// Determine the server from the handshake's address.
+	server, ok := p.servers[h.ServerAddress]
+	if !ok {
+		log.Warn("Unknown server", "server", h.ServerAddress)
+		return minecraftConn.SendDisconnect(fmt.Sprintf("Unknown server: %s", h.ServerAddress))
+	}
+	log = log.With("server", server.config.Hostname)
+
+	// tracks if this connection made it to the login state
+	// HACK(jaredallard): We should do something better than this.
+	var madeItToLogin bool
+
+	// create a new connection
+	conn := NewConnection(minecraftConn, log, server, h, &ConnectionHooks{
+		OnLogin: func(l *minecraft.LoginStart) {
+			log.Info("Login initiated", "username", l.Name)
+			// track that we made it to login state for connection
+			// tracking
+			madeItToLogin = true
+
+			// reset the emptySince time
+			server.emptySince.Store(nil)
+			p.connections.Add(1)
+		},
+		OnClose: func() {
+			// only decrement if we made it to login state, where we
+			// would've incremented the connection count
+			if madeItToLogin {
+				p.connections.Add(^uint64(0))
+			}
+		},
+	})
+	connAddr := rawConn.Socket.RemoteAddr().String()
+
+	// proxy the connection in a goroutine
+	go func() {
+		p.log.Debug("Handling connection", "addr", connAddr)
+		if err := conn.Proxy(ctx); err != nil {
+			p.log.Error("failed to proxy connection", "err", err)
+		}
+		defer conn.Close()
+
+		p.log.Debug("Connection closed", "addr", connAddr)
+	}()
+
+	return nil
 }
 
 // Stop stops the server

--- a/cmd/minecraft-preempt/proxy.go
+++ b/cmd/minecraft-preempt/proxy.go
@@ -223,8 +223,9 @@ func (p *Proxy) Stop(ctx context.Context) error {
 
 	// wait for all connections to drain
 	for _, server := range p.servers {
-		if server.connections.Load() > 0 {
-			p.log.Info("Waiting for connections to drain during shutdown")
+		connections := server.connections.Load()
+		if connections > 0 {
+			p.log.Info("Waiting for connections to drain during shutdown", "server", server.config.Hostname, "connections", connections)
 
 			for {
 				// check if we have no connections

--- a/cmd/minecraft-preempt/server.go
+++ b/cmd/minecraft-preempt/server.go
@@ -46,6 +46,10 @@ type Server struct {
 
 	// lastMinecraftStatus is the last status we got from the minecraft server
 	lastMinecraftStatus atomic.Pointer[minecraft.Status]
+
+	// emptySince is the time we've been empty (had no connections)
+	// since
+	emptySince atomic.Pointer[time.Time]
 }
 
 // GetCloudProviderForConfig returns a cloud provider for the provided config

--- a/cmd/minecraft-preempt/server.go
+++ b/cmd/minecraft-preempt/server.go
@@ -50,6 +50,9 @@ type Server struct {
 	// emptySince is the time we've been empty (had no connections)
 	// since
 	emptySince atomic.Pointer[time.Time]
+
+	// connections is the number of connections we have
+	connections atomic.Uint64
 }
 
 // GetCloudProviderForConfig returns a cloud provider for the provided config

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,7 +1,10 @@
+# For WSL:
+# listenAddress: 127.0.0.1:25565
 servers:
-  - name: development
+  - hostname: localhost
     docker:
       containerID: minecraft-preempt-minecraft-1
+    shutdownAfter: 24h
     minecraft:
       hostname: 127.0.0.1
       port: 25566

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,6 @@ services:
     environment:
       EULA: "true"
       TZ: "America/Los_Angeles"
-      VERSION: "1.19.4"
+      VERSION: "1.20.2"
     ports:
       - 127.0.0.1:25566:25565


### PR DESCRIPTION
Instead of using a listener per-server, we now use a single global
listener. This listener defaults to listening on `0.0.0.0:25565`, like
the previous per-server listener did before.

As part of this, the configuration objects have been changed. `name` has
been changed to `hostname`. This hostname should match exactly what the
Minecraft client is using to connect. It is self-reported by the client
during the handshake process[^1]. The example configuration has been
updated to match the new format, as well as the docs. I also added a
WSL-specific `listenAddress` hint to help with port-forwarding issues on
WSL machines.

This is a BREAKING CHANGE because of the configuration changes required,
so I will be releasing a v3 post-merge.

[^1]: https://wiki.vg/Protocol#Handshaking
